### PR TITLE
lint: reviewdog-golangci image with libusb support

### DIFF
--- a/lint/Dockerfile
+++ b/lint/Dockerfile
@@ -3,7 +3,7 @@ ARG GOLANG_VERSION="1.20.1"
 FROM golang:${GOLANG_VERSION}-alpine
 ARG GOLANGCI_LINT_VERSION="1.51.2"
 ARG REVIEWDOG_VERSION="0.14.1"
-ARG PKGS="libusb-dev"
+ARG PKGS
 RUN apk add \
 	build-base \
 	curl \
@@ -14,3 +14,5 @@ RUN apk add \
 	&& rm -rf /var/cache/apk/* \
         && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh    | sh -s -- -b $(go env GOPATH)/bin "v${REVIEWDOG_VERSION}" \
         && curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin "v${GOLANGCI_LINT_VERSION}"
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/lint/entrypoint.sh
+++ b/lint/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd "$GITHUB_WORKSPACE"
+
+REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
+export REVIEWDOG_GITHUB_API_TOKEN
+
+golangci-lint run --out-format line-number ${INPUT_GOLANGCI_LINT_FLAGS} \
+  | reviewdog -f=golangci-lint -name="${INPUT_TOOL_NAME}" -reporter=github-pr-check -level="${INPUT_LEVEL}"


### PR DESCRIPTION
Alpine-based reviewdog-golangci image with libusb support.
